### PR TITLE
Fix: Pre-check for pnpm existing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "scripts": {
+        "pre-install": "npx only-allow pnpm"
         "dev": "nodemon index.js",
         "start": "node index.js",
-        "build": "npm install"
+        "build": "pnpm install",
     },
     "dependencies": {
         "cors": "^2.8.5",


### PR DESCRIPTION
This boilerplate presupposes pnpm being installed and available `pnpm-lock.yaml` have the `package.json` check that tyis tool is indeed the one being used to install before continuing.